### PR TITLE
node-state-server: fix the rwmutex initialization

### DIFF
--- a/internal/controller/node/server.go
+++ b/internal/controller/node/server.go
@@ -45,7 +45,8 @@ type Server struct {
 
 func NewServer() *Server {
 	return &Server{
-		nodes: map[string]NodeState{},
+		nodes:   map[string]NodeState{},
+		RWMutex: &sync.RWMutex{},
 	}
 }
 


### PR DESCRIPTION
The node-state-server ported code has [some missing pieces](https://github.com/qawolf/crik/issues/1#issue-2226640620) apparently, and this is one of them. It causes crash when queried.