### PR TITLE
fix(charts): switch role and roleBinding to cluster scoped permissions

### DIFF
--- a/cluster/charts/crik-node-state-server/templates/manager-permissions.yaml
+++ b/cluster/charts/crik-node-state-server/templates/manager-permissions.yaml
@@ -38,4 +38,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: crik-node-state-server
-    namespace: default
+    namespace: {{ .Release.Namespace }}

--- a/cluster/charts/crik-node-state-server/templates/manager-permissions.yaml
+++ b/cluster/charts/crik-node-state-server/templates/manager-permissions.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/part-of: crik
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: crik-node-state-server
   labels:
@@ -25,7 +25,7 @@ rules:
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: crik-node-state-server
   labels:
@@ -33,8 +33,9 @@ metadata:
     app.kubernetes.io/part-of: crik
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: crik-node-state-server
 subjects:
   - kind: ServiceAccount
     name: crik-node-state-server
+    namespace: default


### PR DESCRIPTION
The node-state server is not able to query clusterResource with adtual set of permissions

Based on this issue : #1 

Changing them from Role and RoleBinding to ClusterRole and ClusterRoleBinding